### PR TITLE
Rewrote browse APIs, support for backupset level browse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,14 +54,23 @@ Run backup for a backupset:
 Run backup for a subclient:
 	>>> job = subclient.backup(backup_level, incremental_backup, incremental_level)
 
-Browsing content of a subclient:
-	>>> paths, dictionary = subclient.browse(path, show_deleted_files, vm_file_browse, vm_disk_browse)
+Browsing content at subclient level:
+	>>> paths, dictionary = subclient.browse(path = 'c:\\', show_deleted = True)
 
 Browsing content of a subclient in a specific time range:
-	>>> paths, dictionary = subclient.browse_in_time(path, show_deleted_files, restore_index, from_date, to_date)
+	>>> paths, dictionary = subclient.browse(path = 'f:\\', from_time = '2010-04-19 02:30:00', to_time = '2014-12-20 12:00:00')
 
 Searching a file in subclient backup content:
-	>>> paths, dictionary = subclient.find(file_or_folder_name, show_deleted_files, restore_index)
+	>>> paths, dictionary = subclient.find(file_name = "*.txt")
+
+Browsing content at backupset level:
+	>>> paths, dictionary = backupset.browse(path = 'c:\\', show_deleted = True)
+
+Browsing content of a backupset in a specific time range:
+	>>> paths, dictionary = backupset.browse(path = 'f:\\', from_time = '2010-04-19 02:30:00', to_time = '2014-12-20 12:00:00')
+
+Searching a file in backupset backup content:
+	>>> paths, dictionary = backupset.find(file_name = "*.csv")
 
 Run restore in place job for a subclient:
 	>>> job = subclient.restore_in_place(paths, overwrite, restore_data_and_acl)

--- a/README.rst
+++ b/README.rst
@@ -55,22 +55,22 @@ Run backup for a subclient:
 	>>> job = subclient.backup(backup_level, incremental_backup, incremental_level)
 
 Browsing content at subclient level:
-	>>> paths, dictionary = subclient.browse(path = 'c:\\', show_deleted = True)
+	>>> paths, dictionary = subclient.browse(path='c:\\', show_deleted=True)
 
 Browsing content of a subclient in a specific time range:
-	>>> paths, dictionary = subclient.browse(path = 'f:\\', from_time = '2010-04-19 02:30:00', to_time = '2014-12-20 12:00:00')
+	>>> paths, dictionary = subclient.browse(path='f:\\', from_time='2010-04-19 02:30:00', to_time='2014-12-20 12:00:00')
 
 Searching a file in subclient backup content:
-	>>> paths, dictionary = subclient.find(file_name = "*.txt")
+	>>> paths, dictionary = subclient.find(file_name="*.txt")
 
 Browsing content at backupset level:
-	>>> paths, dictionary = backupset.browse(path = 'c:\\', show_deleted = True)
+	>>> paths, dictionary = backupset.browse(path='c:\\', show_deleted=True)
 
 Browsing content of a backupset in a specific time range:
-	>>> paths, dictionary = backupset.browse(path = 'f:\\', from_time = '2010-04-19 02:30:00', to_time = '2014-12-20 12:00:00')
+	>>> paths, dictionary = backupset.browse(path='f:\\', from_time='2010-04-19 02:30:00', to_time='2014-12-20 12:00:00')
 
 Searching a file in backupset backup content:
-	>>> paths, dictionary = backupset.find(file_name = "*.csv")
+	>>> paths, dictionary = backupset.find(file_name="*.csv")
 
 Run restore in place job for a subclient:
 	>>> job = subclient.restore_in_place(paths, overwrite, restore_data_and_acl)

--- a/README.rst
+++ b/README.rst
@@ -42,14 +42,35 @@ Get a client:
 Get an agent:
 	>>> agent = client.agents.get(agent_name)
 
-Get a backupset:
-	>>> backupset = agent.backupsets.get(backupset_name)
+Get an instance:
+	>>> instance = agent.instances.get(instance_name)
 
-Get a subclient:
-	>>> subclient = backupset.subclients.get(subclient_name)
+Browsing content at instance level:
+	>>> paths, dictionary = instance.browse(path='c:\\', show_deleted=True)
+
+Browsing content of a instance in a specific time range:
+	>>> paths, dictionary = instance.browse(path='f:\\', from_time='2010-04-19 02:30:00', to_time='2014-12-20 12:00:00')
+
+Searching a file in instance backup content:
+	>>> paths, dictionary = instance.find(file_name="*.csv")
+
+Get a backupset:
+	>>> backupset = instance.backupsets.get(backupset_name)
 
 Run backup for a backupset:
 	>>> job = backupset.backup()
+
+Browsing content at backupset level:
+	>>> paths, dictionary = backupset.browse(path='c:\\', show_deleted=True)
+
+Browsing content of a backupset in a specific time range:
+	>>> paths, dictionary = backupset.browse(path='f:\\', from_time='2010-04-19 02:30:00', to_time='2014-12-20 12:00:00')
+
+Searching a file in backupset backup content:
+	>>> paths, dictionary = backupset.find(file_name="*.csv")
+
+Get a subclient:
+	>>> subclient = backupset.subclients.get(subclient_name)
 
 Run backup for a subclient:
 	>>> job = subclient.backup(backup_level, incremental_backup, incremental_level)
@@ -62,15 +83,6 @@ Browsing content of a subclient in a specific time range:
 
 Searching a file in subclient backup content:
 	>>> paths, dictionary = subclient.find(file_name="*.txt")
-
-Browsing content at backupset level:
-	>>> paths, dictionary = backupset.browse(path='c:\\', show_deleted=True)
-
-Browsing content of a backupset in a specific time range:
-	>>> paths, dictionary = backupset.browse(path='f:\\', from_time='2010-04-19 02:30:00', to_time='2014-12-20 12:00:00')
-
-Searching a file in backupset backup content:
-	>>> paths, dictionary = backupset.find(file_name="*.csv")
 
 Run restore in place job for a subclient:
 	>>> job = subclient.restore_in_place(paths, overwrite, restore_data_and_acl)

--- a/cvpysdk/backupset.py
+++ b/cvpysdk/backupset.py
@@ -842,7 +842,7 @@ class Backupset(object):
                         temp_dict['criteria']['dataOperator'] = filter[2]
 
                     request_json['queries'][0]['whereClause'].append(temp_dict)
-        print request_json
+        
         return request_json
 
     def _process_browse_response(self, flag, response, options):

--- a/cvpysdk/backupset.py
+++ b/cvpysdk/backupset.py
@@ -777,10 +777,21 @@ class Backupset(object):
         if options['operation'] not in operation_types:
             options['operation'] = 'find'
 
+        # add the browse mode value here, if it is different for an agent
+        # if agent is not added in the dict, default value 2 will be used
+        browse_mode = {
+            'virtual server': 4
+        }
+
+        mode = 2
+
+        if self._agent_object.agent_name in browse_mode:
+            mode = browse_mode[self._agent_object.agent_name]
+
         request_json = {
             "opType": operation_types[options['operation']],
             "mode": {
-                "mode": 2
+                "mode": mode
             },
             "paths": [{
                 "path": options['path']

--- a/cvpysdk/backupset.py
+++ b/cvpysdk/backupset.py
@@ -697,11 +697,11 @@ class Backupset(object):
         return self._process_update_reponse(request_json)
 
     @staticmethod
-    def _get_timestamp(timestamp):
-        """ Returns the timestamp which are in the format %Y-%m-%d %H:%M:%S
+    def _get_timestamp(formatted_time):
+        """ Returns the epoch timestamp given the input time is in format %Y-%m-%d %H:%M:%S
         
         Args:
-            time_value          (multiple)  --  Integer of timestamp or string of formatted time
+            formatted_time          (multiple)  --  String of formatted time or integer of timestamp
             
         Returns:
             (int)- Timestamp
@@ -711,16 +711,16 @@ class Backupset(object):
                 If the timestamp cannot be obtained
         """
 
-        if str(timestamp) == '0':
+        if str(formatted_time) == '0':
             return 0
 
         try:  # Try converting the value to Integer, if possible then return it.
-            timestamp = int(timestamp)
+            timestamp = int(formatted_time)
             return timestamp
 
         except ValueError:  # If not convertible to integer, then get the timestamp from formatted time
             try:
-                return int(time.mktime(datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").timetuple()))
+                return int(time.mktime(datetime.datetime.strptime(formatted_time, "%Y-%m-%d %H:%M:%S").timetuple()))
             except:
                 raise SDKException('Subclient', '106')
 
@@ -1105,13 +1105,15 @@ class Backupset(object):
                     Example-  
                         browse({ 
                             'path': 'c:\\hello',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
                         })
 
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='c:\\hello', show_deleted=True )
+                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
                 Refer self.default_browse_options for all the supported options
 
@@ -1138,13 +1140,15 @@ class Backupset(object):
                 Example-  
                     find({
                         'file_name': '*.txt',
-                        'show_deleted': True
+                        'show_deleted': True,
+                        'from_time': '2014-04-20 12:00:00',
+                        'to_time': '2016-04-31 12:00:00'
                     })
 
             (or)
 
             Keyword argument of browse options 
-                Example-   find( file_name='*.txt', show_deleted=True )
+                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
             Refer self.default_browse_options for all the supported options
 

--- a/cvpysdk/backupset.py
+++ b/cvpysdk/backupset.py
@@ -60,7 +60,7 @@ Backupset:
 
     _set_defaults()                 -- recursively sets default values on a dictionary
 
-    _default_browse_options()       -- prepares the options for the Browse/find operation
+    _prepare_browse_options()       -- prepares the options for the Browse/find operation
 
     _prepare_browse_json()          -- prepares the JSON object for the browse request
 

--- a/cvpysdk/backupset.py
+++ b/cvpysdk/backupset.py
@@ -514,8 +514,8 @@ class Backupset(object):
         self.default_browse_options = {
             'operation': 'browse',
             'show_deleted': False,
-            'from_time': 0,  # Timestamp or %Y-%m-%d %H:%M:%S
-            'to_time': 0,  # Timestamp or %Y-%m-%d %H:%M:%S
+            'from_time': 0,  # Timestamp ( string or integer ) or %Y-%m-%d %H:%M:%S ( string )
+            'to_time': 0,  # Timestamp ( string or integer ) or %Y-%m-%d %H:%M:%S ( string )
             'path': '\\',
             'copy_precedence': 0,
             'media_agent': '',
@@ -701,10 +701,10 @@ class Backupset(object):
         """ Returns the epoch timestamp given the input time is in format %Y-%m-%d %H:%M:%S
         
         Args:
-            formatted_time          (multiple)  --  String of formatted time or integer of timestamp
+            formatted_time   (mixed)  --  String of formatted time or integer/string of timestamp
             
         Returns:
-            (int)- Timestamp
+            int - Timestamp
             
         Raises:
             SDKException:
@@ -728,8 +728,8 @@ class Backupset(object):
         """ Recursively sets default values on a dictionary
 
         Args:
-            custom                  (dict)    --  The dictionary which has to be set with defaults
-            defaults                (dict)    --  The dictionary with default values
+            custom     (dict)    --  The dictionary which has to be set with defaults
+            defaults   (dict)    --  The dictionary with default values
 
         Returns:
             None
@@ -747,10 +747,10 @@ class Backupset(object):
         """ Prepares the options for the Browse/find operation
 
         Args:
-            options             (dict)    --   A dictionary of browse options
+            options   (dict)   --   A dictionary of browse options
 
         Returns:
-            (dict): The browse options with all the default options set
+            dict - The browse options with all the default options set
 
         """
 
@@ -762,10 +762,10 @@ class Backupset(object):
         """ Prepares the JSON object for the browse request
 
         Args:
-            options                 (dict)   --    The browse options dictionary
+            options   (dict)   --    The browse options dictionary
 
         Returns:
-            (dict): A JSON object for the browse response
+            dict - A JSON object for the browse response
 
         """
 
@@ -849,13 +849,13 @@ class Backupset(object):
         """ Retrieves the items from browse response
 
         Args:
-            flag            (bool)  --  boolean, whether the response was success or not
-            response        (dict)  --  JSON response received for the request from the Server
-            options         (dict)  --  The browse options dictionary
+            flag        (bool)  --  boolean, whether the response was success or not
+            response    (dict)  --  JSON response received for the request from the Server
+            options     (dict)  --  The browse options dictionary
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         Raises:
             SDKException:
@@ -948,11 +948,11 @@ class Backupset(object):
         """ Performs a browse operation with the given options
 
         Args:
-            options         (dict)   --   Dictionary of browse options
+            options    (dict)   --   Dictionary of browse options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -1113,13 +1113,13 @@ class Backupset(object):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                    Example - browse( path='c:\\hello', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
                 Refer self.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -1148,7 +1148,7 @@ class Backupset(object):
             (or)
 
             Keyword argument of browse options 
-                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                Example - find( file_name='*.txt', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
             Refer self.default_browse_options for all the supported options
 
@@ -1159,8 +1159,8 @@ class Backupset(object):
                 file_size_et    (int)   --   Find files with size equal to size
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 

--- a/cvpysdk/exception.py
+++ b/cvpysdk/exception.py
@@ -57,7 +57,8 @@ EXCEPTION_DICT = {
     'Instance': {
         '101': 'Data type of the input(s) is not valid',
         '102': '',
-        '103': 'Input date is incorrect'
+        '103': 'Input date is incorrect',
+        '104': 'Instance Level Browse is not supported. Instance should have a single backupset'
     },
     'Subclient': {
         '101': 'Data type of the input(s) is not valid',

--- a/cvpysdk/instance.py
+++ b/cvpysdk/instance.py
@@ -304,91 +304,105 @@ class Instance(object):
         return self._instance_name
 
     def browse(self, *args, **kwargs):
-        """ Performs a browse operation on the instance if only one backupset is available
+        """Browses the content of a Backupset.
 
             Args:
-                Dictionary of browse options
-                    Example-  
+                Dictionary of browse options:
+                    Example:
                         browse({
                             'path': 'c:\\hello',
                             'show_deleted': True,
                             'from_time': '2014-04-20 12:00:00',
-                            'to_time': '2016-04-31 12:00:00'
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example -   browse( path='c:\\hello', show_deleted=True, to_time='2016-04-31 12:00:00' )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='c:\\hello',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer self._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
-        
+
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
+
         Raises:
             SDKException:
-                If there are more than one backupsets in the instance 
-        
+                if there are more than one backupsets in the instance
         """
+        all_backupsets = self.backupsets._backupsets
 
-        all_backupsets = self.backupsets._get_backupsets()
+        # do browse operation if there is only one backupset in the instance
+        # raise `SDKException` if there is more than one backupset in the instance
 
-        # If there is only one backupset, then perform backupset level browse on it
-        if len(all_backupsets.keys()) == 1:
+        if len(all_backupsets) == 1:
             backupset_name = all_backupsets.keys()[0]
             temp_backupset_obj = self.backupsets.get(backupset_name)
             return temp_backupset_obj.browse(*args, **kwargs)
-
-        # If there are more than one backupset, then raise exception
         else:
-            raise SDKException(
-                'Instance', '102', 'Cannot perform instance level browse. There are multiple backupsets'
-            )
+            raise SDKException('Instance', '104')
 
     def find(self, *args, **kwargs):
-        """ Performs a find operation on the instance if only one backupset is available
+        """Searches a file/folder in the backupset backup content,
+            and returns all the files matching the filters given.
 
          Args:
-            Dictionary of browse options
-                Example-  
+            Dictionary of find options:
+                Example:
                     find({
                         'file_name': '*.txt',
                         'show_deleted': True,
                         'from_time': '2014-04-20 12:00:00',
-                        'to_time': '2016-04-31 12:00:00'
+                        'to_time': '2016-04-21 12:00:00'
                     })
 
-            (or)
+                (OR)
 
-            Keyword argument of browse options 
-                Example -   find( file_name='*.txt', show_deleted=True, to_time='2016-04-31 12:00:00' )
+            Keyword argument of find options:
+                Example:
+                    find(
+                        file_name='*.txt',
+                        show_deleted=True,
+                        from_time=2014-04-20 12:00:00,
+                        to_time='2016-04-21 12:00:00'
+                    )
 
-            Refer self.default_browse_options for all the supported options
+            Refer self._default_browse_options for all the supported options
 
             Additional options supported:
                 file_name       (str)   --   Find files with name
+
                 file_size_gt    (int)   --   Find files with size greater than size
+
                 file_size_lt    (int)   --   Find files with size lesser than size
+
                 file_size_et    (int)   --   Find files with size equal to size
 
         Returns:
-            list -  List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
+
+        Raises:
+            SDKException:
+                if there are more than one backupsets in the instance
         """
-
         all_backupsets = self.backupsets._get_backupsets()
 
-        # If there is only one backupset, then perform backupset level find on it
-        if len(all_backupsets.keys()) == 1:
-            the_lone_backupset = all_backupsets.keys()[0]
-            temp_backupset_obj = self.backupsets.get(the_lone_backupset)
-            return temp_backupset_obj.find(*args, **kwargs)
+        # do find operation if there is only one backupset in the instance
+        # raise `SDKException` if there is more than one backupset in the instance
 
-        # If there are more than one backupset, then raise exception
+        if len(all_backupsets) == 1:
+            backupset_name = all_backupsets.keys()[0]
+            temp_backupset_obj = self.backupsets.get(backupset_name)
+            return temp_backupset_obj.find(*args, **kwargs)
         else:
-            raise SDKException(
-                'Instance', '102', 'Cannot perform instance level find. There are multiple backupsets'
-            )
+            raise SDKException('Instance', '104')

--- a/cvpysdk/instance.py
+++ b/cvpysdk/instance.py
@@ -302,3 +302,93 @@ class Instance(object):
     def instance_name(self):
         """Treats the instance name as a read-only attribute."""
         return self._instance_name
+
+    def browse(self, *args, **kwargs):
+        """ Performs a browse operation on the instance if only one backupset is available
+
+            Args:
+                Dictionary of browse options
+                    Example-  
+                        browse({
+                            'path': 'c:\\hello',
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
+                        })
+
+                (or)
+
+                Keyword argument of browse options 
+                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+
+                Refer Backupset.default_browse_options for all the supported options
+
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+        
+        Raises:
+            SDKException:
+                If there are more than one backupsets in the instance 
+        
+        """
+
+        all_backupsets = self.backupsets._get_backupsets()
+
+        # If there is only one backupset, then perform backupset level browse on it
+        if len(all_backupsets.keys()) == 1:
+            the_lone_backupset = all_backupsets.keys()[0]
+            temp_backupset_obj = self.backupsets.get(the_lone_backupset)
+            return temp_backupset_obj.browse(*args, **kwargs)
+
+        # If there are more than one backupset, then raise exception
+        else:
+            raise SDKException(
+                'Instance', '102', 'Cannot perform instance level browse. There are multiple backupsets'
+            )
+
+    def find(self, *args, **kwargs):
+        """ Performs a find operation on the instance if only one backupset is available
+
+         Args:
+            Dictionary of browse options
+                Example-  
+                    find({
+                        'file_name': '*.txt',
+                        'show_deleted': True,
+                        'from_time': '2014-04-20 12:00:00',
+                        'to_time': '2016-04-31 12:00:00'
+                    })
+
+            (or)
+
+            Keyword argument of browse options 
+                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+
+            Refer self.default_browse_options for all the supported options
+
+            Additional options supported:
+                file_name       (str)   --   Find files with name
+                file_size_gt    (int)   --   Find files with size greater than size
+                file_size_lt    (int)   --   Find files with size lesser than size
+                file_size_et    (int)   --   Find files with size equal to size
+
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+
+        """
+
+        all_backupsets = self.backupsets._get_backupsets()
+
+        # If there is only one backupset, then perform backupset level find on it
+        if len(all_backupsets.keys()) == 1:
+            the_lone_backupset = all_backupsets.keys()[0]
+            temp_backupset_obj = self.backupsets.get(the_lone_backupset)
+            return temp_backupset_obj.find(*args, **kwargs)
+
+        # If there are more than one backupset, then raise exception
+        else:
+            raise SDKException(
+                'Instance', '102', 'Cannot perform instance level find. There are multiple backupsets'
+            )

--- a/cvpysdk/instance.py
+++ b/cvpysdk/instance.py
@@ -319,13 +319,13 @@ class Instance(object):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                    Example -   browse( path='c:\\hello', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
         
         Raises:
             SDKException:
@@ -337,8 +337,8 @@ class Instance(object):
 
         # If there is only one backupset, then perform backupset level browse on it
         if len(all_backupsets.keys()) == 1:
-            the_lone_backupset = all_backupsets.keys()[0]
-            temp_backupset_obj = self.backupsets.get(the_lone_backupset)
+            backupset_name = all_backupsets.keys()[0]
+            temp_backupset_obj = self.backupsets.get(backupset_name)
             return temp_backupset_obj.browse(*args, **kwargs)
 
         # If there are more than one backupset, then raise exception
@@ -363,7 +363,7 @@ class Instance(object):
             (or)
 
             Keyword argument of browse options 
-                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                Example -   find( file_name='*.txt', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
             Refer self.default_browse_options for all the supported options
 
@@ -374,8 +374,8 @@ class Instance(object):
                 file_size_et    (int)   --   Find files with size equal to size
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list -  List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 

--- a/cvpysdk/subclient.py
+++ b/cvpysdk/subclient.py
@@ -1583,7 +1583,7 @@ class Subclient(object):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='c:\\hello', show_deleted=True )
+                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
                 Refer Backupset.default_browse_options for all the supported options
 
@@ -1610,13 +1610,15 @@ class Subclient(object):
                 Example-  
                     find({ 
                         'file_name': '*.txt',
-                        'show_deleted': True
+                        'show_deleted': True,
+                        'from_time': '2014-04-20 12:00:00',
+                        'to_time': '2016-04-31 12:00:00'
                     })
 
             (or)
 
             Keyword argument of browse options 
-                Example-   find( file_name='*.txt', show_deleted=True )
+                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
             Refer Backupset.default_browse_options for all the supported options
 

--- a/cvpysdk/subclient.py
+++ b/cvpysdk/subclient.py
@@ -38,43 +38,65 @@ Subclients:
 Subclient:
     __init__(backupset_object,
              subclient_name,
-             subclient_id)      --  initialise instance of the Subclient class,
-                                        associated to the specified backupset
+             subclient_id)              --  initialise instance of the Subclient class,
+                                                associated to the specified backupset
 
-    __repr__()                  --  return the subclient name, the instance is associated with
+    __repr__()                          --  return the subclient name, the instance is associated
+                                                with
 
-    _get_subclient_id()         --  method to get subclient id, if not specified in __init__ method
+    _get_subclient_id()                 --  method to get subclient id, if not specified in
+                                                __init__ method
 
-    _get_subclient_properties() --  get the properties of this subclient
+    _get_subclient_properties()         --  get the properties of this subclient
 
-    _initialize_subclient_properties() --  initializes the properties of this subclient
+    _initialize_subclient_properties()  --  initializes the properties of this subclient
 
-    _update()                   --  updates the properties of a subclient
+    _update()                           --  updates the properties of a subclient
 
-    _filter_paths()             --  filters the path as per the OS, and the Agent
+    _filter_paths()                     --  filters the path as per the OS, and the Agent
 
-    _process_backup_request()   --  runs the backup request provided, and processes the response
+    _process_backup_response()          --  process response received from backup request
 
-    _restore_json()             --  returns the apppropriate JSON request to pass for either
-                                        Restore In-Place or Out-of-Place operation
+    _browse_and_find_json()             --  returns the appropriate JSON request to pass for either
+                                                Browse operation or Find operation
 
-    _process_restore_response() --  processes response received for the Restore request
+    _process_browse_response()          --  processes response received for both Browse and Find
+                                                request
 
-    description()               --  update the description of the subclient
+    _restore_json()                     --  returns the apppropriate JSON request to pass for
+                                                either Restore In-Place or Out-of-Place operation
 
-    content()                   --  update the content of the subclient
+    _process_restore_response()         --  processes response received for the Restore request
 
-    enable_backup()             --  enables the backup for the subclient
+    description()                       --  update the description of the subclient
 
-    enable_backup_at_time()     --  enables backup for the subclient at the input time specified
+    content()                           --  update the content of the subclient
 
-    disble_backup()             --  disbles the backup for the subclient
+    storage_policy()                    --  update the storage policy for this subclient
 
-    backup()                    --  run a backup job for the subclient
+    enable_backup()                     --  enables the backup for the subclient
 
-    browse()                    --  Performs a browse operation on the subclient
-    
-    find()                      --  Performs a find operation on the subclient
+    enable_backup_at_time()             --  enables backup for the subclient at the input time
+                                                specified
+
+    disable_backup()                    --  disables the backup for the subclient
+
+    enable_intelli_snap()               --  enables the intelli snap for the subclient
+
+    disable_intelli_snap()              --  disables the intelli snap for subclient
+
+    backup()                            --  run a backup job for the subclient
+
+    browse()                            --  gets the content of the backup for this subclient
+                                                at the path specified
+
+    browse_in_time()            --  gets the content of the backup for this subclient
+                                        at the input path in the time range specified
+
+    find()                      --  searches a given file/folder name in the subclient content
+
+    restore_in_place()          --  Restores the files/folders specified in the
+                                        input paths list to the same location
 
     restore_out_of_place()      --  Restores the files/folders specified in the input paths list
                                         to the input client, at the specified destionation location
@@ -1570,29 +1592,36 @@ class Subclient(object):
         return self._process_backup_response(flag, response)
 
     def browse(self, *args, **kwargs):
-        """ Performs a browse operation on the subclient
+        """Browses the content of a Subclient.
 
             Args:
-                Dictionary of browse options
-                    Example-  
+                Dictionary of browse options:
+                    Example:
                         browse({
                             'path': 'c:\\hello',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example -   browse( path='c:\\hello', show_deleted=True, to_time='2016-04-31 12:00:00' )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='c:\\hello',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer Backupset._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
-
         if len(args) > 0 and type(args[0]) == dict:
             options = args[0]
         else:
@@ -1603,37 +1632,46 @@ class Subclient(object):
         return self._backupset_object.browse(options)
 
     def find(self, *args, **kwargs):
-        """ Performs a find operation on the subclient
+        """Searches a file/folder in the subclient backup content,
+            and returns all the files matching the filters given.
 
          Args:
-            Dictionary of browse options
-                Example-  
-                    find({ 
+            Dictionary of find options:
+                Example:
+                    find({
                         'file_name': '*.txt',
                         'show_deleted': True,
                         'from_time': '2014-04-20 12:00:00',
-                        'to_time': '2016-04-31 12:00:00'
+                        'to_time': '2016-04-21 12:00:00'
                     })
 
-            (or)
+                (OR)
 
-            Keyword argument of browse options 
-                Example - find( file_name='*.txt', show_deleted=True, to_time='2016-04-31 12:00:00' )
+            Keyword argument of find options:
+                Example:
+                    find(
+                        file_name='*.txt',
+                        show_deleted=True,
+                        from_time=2014-04-20 12:00:00,
+                        to_time='2016-04-21 12:00:00'
+                    )
 
-            Refer Backupset.default_browse_options for all the supported options
+            Refer Backupset._default_browse_options for all the supported options
 
             Additional options supported:
                 file_name       (str)   --   Find files with name
+
                 file_size_gt    (int)   --   Find files with size greater than size
+
                 file_size_lt    (int)   --   Find files with size lesser than size
+
                 file_size_et    (int)   --   Find files with size equal to size
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
-
         if len(args) > 0 and type(args[0]) == dict:
             options = args[0]
         else:

--- a/cvpysdk/subclient.py
+++ b/cvpysdk/subclient.py
@@ -1583,13 +1583,13 @@ class Subclient(object):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='c:\\hello', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                    Example -   browse( path='c:\\hello', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -1618,7 +1618,7 @@ class Subclient(object):
             (or)
 
             Keyword argument of browse options 
-                Example-   find( file_name='*.txt', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                Example - find( file_name='*.txt', show_deleted=True, to_time='2016-04-31 12:00:00' )
 
             Refer Backupset.default_browse_options for all the supported options
 
@@ -1629,8 +1629,8 @@ class Subclient(object):
                 file_size_et    (int)   --   Find files with size equal to size
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 

--- a/cvpysdk/subclients/vssubclient.py
+++ b/cvpysdk/subclients/vssubclient.py
@@ -69,12 +69,13 @@ class VirtualServerSubclient(Subclient):
         content = []
 
         content_types = {
-            '1': 'Host',
-            '2': 'Resource Pool',
-            '4': 'Datacenter',
-            '9': 'Virtual Machine',
-            '16': 'All unprotected VMs',
-            '17': 'Root'
+            1: 'Host',
+            2: 'Resource Pool',
+            4: 'Datacenter',
+            9: 'Virtual Machine',
+            16: 'All unprotected VMs',
+            17: 'Root',
+            35: 'Tag Category'
         }
 
         if 'vmContent' in self._subclient_properties:
@@ -113,12 +114,13 @@ class VirtualServerSubclient(Subclient):
         content = []
 
         content_types = {
-            'Host': '1',
-            'Root': '17',
-            'Datacenter': '4',
-            'Resource Pool': '2',
-            'Virtual Machine': '9',
-            'All unprotected VMs': '16'
+            'Host': 1,
+            'Root': 17,
+            'Datacenter': 4,
+            'Tag Category': 35,
+            'Resource Pool': 2,
+            'Virtual Machine': 9,
+            'All unprotected VMs': 16
         }
 
         try:
@@ -229,39 +231,46 @@ class VirtualServerSubclient(Subclient):
         return restore_content
 
     def browse(self, *args, **kwargs):
-        """ Performs a browse operation on the subclient
+        """Browses the content of the Subclient.
 
             Args:
-                Dictionary of browse options
-                    Example-  
+                Dictionary of browse options:
+                    Example:
                         browse({
                             'path': '\\vmname\\',
                             'show_deleted': True,
                             'from_time': '2014-04-20 12:00:00',
-                            'to_time': '2016-04-31 12:00:00'
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example - browse( path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='\\vmname\\',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer Backupset._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
-
-        if len(args) > 0 and type(args[0]) == dict:
+        if len(args) > 0 and isinstance(args[0], dict):
             options = args[0]
         else:
             options = kwargs
 
         vm_ids, vm_names = self._get_vm_ids_and_names_dict()
 
-        options['path'] = '\\' if 'path' not in options else options['path']
+        if 'path' not in options:
+            options['path'] = '\\'
+
         options['path'] = self._parse_vm_path(vm_names, options['path'])
 
         browse_content = super(VirtualServerSubclient, self).browse(options)
@@ -269,93 +278,114 @@ class VirtualServerSubclient(Subclient):
         return self._process_vsa_browse_response(vm_ids, browse_content)
 
     def guest_files_browse(self, *args, **kwargs):
-        """ Performs a browse operation on the subclient
+        """Browses the content of the Subclient.
 
             Args:
-                Dictionary of browse options
-                    Example-  
-                        guest_files_browse({
+                Dictionary of browse options:
+                    Example:
+                        browse({
                             'path': '\\vmname\\',
                             'show_deleted': True,
                             'from_time': '2014-04-20 12:00:00',
-                            'to_time': '2016-04-31 12:00:00'
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example - guest_files_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00'
-                    )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='\\vmname\\',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer Backupset._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
-
         return self.browse(*args, **kwargs)
 
     def vm_files_browse(self, *args, **kwargs):
-        """ Performs a browse operation on the subclient
+        """Browses the content of the Subclient.
 
             Args:
-                Dictionary of browse options
-                    Example-  
-                        vm_files_browse({
+                Dictionary of browse options:
+                    Example:
+                        browse({
                             'path': '\\vmname\\',
                             'show_deleted': True,
                             'from_time': '2014-04-20 12:00:00',
-                            'to_time': '2016-04-31 12:00:00'
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example - vm_files_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00'
-                    )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='\\vmname\\',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer Backupset._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
+        if len(args) > 0 and isinstance(args[0], dict):
+            options = args[0]
+        else:
+            options = kwargs
 
+        options['vm_disk_browse'] = True
         return self.browse(*args, **kwargs)
 
     def disk_level_browse(self, *args, **kwargs):
-        """ Performs a browse operation on the subclient
+        """Browses the content of the Subclient.
 
             Args:
-                Dictionary of browse options
-                    Example-  
-                        disk_level_browse({
+                Dictionary of browse options:
+                    Example:
+                        browse({
                             'path': '\\vmname\\',
                             'show_deleted': True,
                             'from_time': '2014-04-20 12:00:00',
-                            'to_time': '2016-04-31 12:00:00'
+                            'to_time': '2016-04-21 12:00:00'
                         })
 
-                (or)
+                    (OR)
 
-                Keyword argument of browse options 
-                    Example - disk_level_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00 
-                    )
+                Keyword argument of browse options:
+                    Example:
+                        browse(
+                            path='\\vmname\\',
+                            show_deleted=True,
+                            from_time='2014-04-20 12:00:00',
+                            to_time='2016-04-21 12:00:00'
+                        )
 
-                Refer Backupset.default_browse_options for all the supported options
+                Refer Backupset._default_browse_options for all the supported options
 
         Returns:
             list - List of only the file, folder paths from the browse response
-            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
+            dict - Dictionary of all the paths with additional metadata retrieved from browse
         """
+        if len(args) > 0 and isinstance(args[0], dict):
+            options = args[0]
+        else:
+            options = kwargs
 
+        options['vm_disk_browse'] = True
         browse_content = self.browse(*args, **kwargs)
 
         paths_list = []

--- a/cvpysdk/subclients/vssubclient.py
+++ b/cvpysdk/subclients/vssubclient.py
@@ -236,13 +236,15 @@ class VirtualServerSubclient(Subclient):
                     Example-  
                         browse({
                             'path': '\\vmname\\',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
                         })
 
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='\\vmname\\', show_deleted=True )
+                    Example-   browse( path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
                 Refer Backupset.default_browse_options for all the supported options
 
@@ -274,13 +276,17 @@ class VirtualServerSubclient(Subclient):
                     Example-  
                         guest_files_browse({
                             'path': '\\vmname\\',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
                         })
 
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   guest_files_browse( path='\\vmname\\', show_deleted=True )
+                    Example-   guest_files_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00'
+                    )
 
                 Refer Backupset.default_browse_options for all the supported options
 
@@ -300,13 +306,17 @@ class VirtualServerSubclient(Subclient):
                     Example-  
                         vm_files_browse({
                             'path': '\\vmname\\',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
                         })
 
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   vm_files_browse( path='\\vmname\\', show_deleted=True )
+                    Example-   vm_files_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00'
+                    )
 
                 Refer Backupset.default_browse_options for all the supported options
 
@@ -326,13 +336,17 @@ class VirtualServerSubclient(Subclient):
                     Example-  
                         disk_level_browse({
                             'path': '\\vmname\\',
-                            'show_deleted': True
+                            'show_deleted': True,
+                            'from_time': '2014-04-20 12:00:00',
+                            'to_time': '2016-04-31 12:00:00'
                         })
 
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   disk_level_browse( path='\\vmname\\', show_deleted=True )
+                    Example-   disk_level_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00 
+                    )
 
                 Refer Backupset.default_browse_options for all the supported options
 

--- a/cvpysdk/subclients/vssubclient.py
+++ b/cvpysdk/subclients/vssubclient.py
@@ -33,23 +33,11 @@ VirtualServerSubclient:
     browse()                        --  gets the content of the backup for this subclient
                                             at the vm path specified
 
-    browse_in_time()                --  gets the content of the backup for this subclient
-                                            at the input vm path in the time range specified
-
     guest_files_browse()            --  browses the Files and Folders inside a Virtual Machine
-
-    guest_files_browse_in_time()    --  browses the Files and Folders inside a Virtual Machine
-                                            in the time range specified
 
     vm_files_browse()               --  browses the Files and Folders of a Virtual Machine
 
-    vm_files_browse_in_time()       --  browses the Files and Folders of a Virtual Machine
-                                            in the time range specified
-
     disk_level_browse()             --  browses the Disks of a Virtual Machine
-
-    disk_level_browse_in_time()     --  browses the Disks of a Virtual Machine
-                                            in the time range specified
 
     restore_out_of_place()          --  restores the VM Guest Files specified in the paths list
                                             to the client, at the specified destionation location
@@ -240,359 +228,121 @@ class VirtualServerSubclient(Subclient):
 
         return restore_content
 
-    def browse(self, vm_path='\\', show_deleted_files=True, vm_disk_browse=False):
-        """Gets the content of the backup for this subclient at the path specified.
+    def browse(self, *args, **kwargs):
+        """ Performs a browse operation on the subclient
 
             Args:
-                vm_path             (str)   --  vm path to get the contents of
-                    default: '\\'; returns the root of the Backup content
+                Dictionary of browse options
+                    Example-  
+                        browse({
+                            'path': '\\vmname\\',
+                            'show_deleted': True
+                        })
 
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
+                (or)
 
-                vm_disk_browse      (bool)  --  browse virtual machine files
-                                                    e.g.; .vmdk files, etc.
-                    only applicable when browsing content inside a guest virtual machine
-                    default: False
+                Keyword argument of browse options 
+                    Example-   browse( path='\\vmname\\', show_deleted=True )
 
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
+                Refer Backupset.default_browse_options for all the supported options
 
-                dict - path along with the details like name, file/folder, size, modification time
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
 
-            Raises:
-                SDKException:
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
         """
-        vm_ids, vm_names = self._get_vm_ids_and_names_dict()
 
-        vm_path = self._parse_vm_path(vm_names, vm_path)
-
-        browse_content = super(VirtualServerSubclient, self).browse(
-            vm_path, show_deleted_files, vm_disk_browse, True
-        )
-
-        return self._process_vsa_browse_response(vm_ids, browse_content)
-
-    def browse_in_time(
-            self,
-            vm_path='\\',
-            show_deleted_files=True,
-            restore_index=True,
-            vm_disk_browse=False,
-            from_date=None,
-            to_date=None):
-        """Gets the content of the backup for this subclient
-            at the path specified in the time range specified.
-
-            Args:
-                vm_path             (str)   --  folder path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-                restore_index       (bool)  --  restore index if it is not cached
-                    default: True
-
-                from_date           (str)   --  date to get the contents after
-                        format: dd/MM/YYYY
-
-                        gets contents from 01/01/1970 if not specified
-                    default: None
-
-                to_date             (str)  --  date to get the contents before
-                        format: dd/MM/YYYY
-
-                        gets contents till current day if not specified
-                    default: None
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if from date value is incorrect
-
-                    if to date value is incorrect
-
-                    if to date is less than from date
-
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        vm_ids, vm_names = self._get_vm_ids_and_names_dict()
-
-        vm_path = self._parse_vm_path(vm_names, vm_path)
-
-        browse_content = super(VirtualServerSubclient, self).browse_in_time(
-            vm_path, show_deleted_files, restore_index, vm_disk_browse, from_date, to_date, True
-        )
-
-        return self._process_vsa_browse_response(vm_ids, browse_content)
-
-    def guest_files_browse(self, vm_path='\\', show_deleted_files=True):
-        """Browses the Files and Folders inside a Virtual Machine.
-
-            Args:
-                vm_path             (str)   --  vm path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        return self.browse(vm_path, show_deleted_files, False)
-
-    def guest_files_browse_in_time(
-            self,
-            vm_path='\\',
-            show_deleted_files=True,
-            restore_index=True,
-            from_date=None,
-            to_date=None):
-        """Browses the Files and Folders inside a Virtual Machine in the time range specified.
-
-            Args:
-                vm_path             (str)   --  folder path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-                restore_index       (bool)  --  restore index if it is not cached
-                    default: True
-
-                from_date           (str)   --  date to get the contents after
-                        format: dd/MM/YYYY
-
-                        gets contents from 01/01/1970 if not specified
-                    default: None
-
-                to_date             (str)  --  date to get the contents before
-                        format: dd/MM/YYYY
-
-                        gets contents till current day if not specified
-                    default: None
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if from date value is incorrect
-
-                    if to date value is incorrect
-
-                    if to date is less than from date
-
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        return self.browse_in_time(
-            vm_path, show_deleted_files, restore_index, False, from_date, to_date
-        )
-
-    def vm_files_browse(self, vm_path='\\', show_deleted_files=True):
-        """Browses the Files and Folders of a Virtual Machine.
-
-            Args:
-                vm_path             (str)   --  vm path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        return self.browse(vm_path, show_deleted_files, True)
-
-    def vm_files_browse_in_time(
-            self,
-            vm_path='\\',
-            show_deleted_files=True,
-            restore_index=True,
-            from_date=None,
-            to_date=None):
-        """Browses the Files and Folders of a Virtual Machine in the time range specified.
-
-            Args:
-                vm_path             (str)   --  folder path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-                restore_index       (bool)  --  restore index if it is not cached
-                    default: True
-
-                from_date           (str)   --  date to get the contents after
-                        format: dd/MM/YYYY
-
-                        gets contents from 01/01/1970 if not specified
-                    default: None
-
-                to_date             (str)  --  date to get the contents before
-                        format: dd/MM/YYYY
-
-                        gets contents till current day if not specified
-                    default: None
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if from date value is incorrect
-
-                    if to date value is incorrect
-
-                    if to date is less than from date
-
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        return self.browse_in_time(
-            vm_path, show_deleted_files, restore_index, True, from_date, to_date
-        )
-
-    def disk_level_browse(self, vm_path='\\', show_deleted_files=True):
-        """Browses the Disks of a Virtual Machine.
-
-            Args:
-                vm_path             (str)   --  vm path to get the contents of
-                    default: '\\'; returns the root of the Backup content
-
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
-        """
-        browse_content = self.browse(vm_path, show_deleted_files, True)
-
-        paths_list = []
-
-        for path in browse_content[0]:
-            if path.endswith('.vmdk'):
-                paths_list.append(path)
-
-        paths_dict = {}
-
-        for path in browse_content[1]:
-            if path.endswith('.vmdk'):
-                paths_dict[path] = browse_content[1][path]
-
-        if paths_list and paths_dict:
-            return paths_list, paths_dict
+        if len(args) > 0 and type(args[0]) == dict:
+            options = args[0]
         else:
-            return browse_content
+            options = kwargs
 
-    def disk_level_browse_in_time(
-            self,
-            vm_path='\\',
-            show_deleted_files=True,
-            restore_index=True,
-            from_date=None,
-            to_date=None):
-        """Browses the Disks of a Virtual Machine in the time range specified.
+        vm_ids, vm_names = self._get_vm_ids_and_names_dict()
+
+        options['path'] = '\\' if 'path' not in options else options['path']
+        options['path'] = self._parse_vm_path(vm_names, options['path'])
+
+        browse_content = super(VirtualServerSubclient, self).browse(options)
+
+        return self._process_vsa_browse_response(vm_ids, browse_content)
+
+    def guest_files_browse(self, *args, **kwargs):
+        """ Performs a browse operation on the subclient
 
             Args:
-                vm_path             (str)   --  folder path to get the contents of
-                    default: '\\'; returns the root of the Backup content
+                Dictionary of browse options
+                    Example-  
+                        guest_files_browse({
+                            'path': '\\vmname\\',
+                            'show_deleted': True
+                        })
 
-                show_deleted_files  (bool)  --  include deleted files in the content or not
-                    default: True
+                (or)
 
-                restore_index       (bool)  --  restore index if it is not cached
-                    default: True
+                Keyword argument of browse options 
+                    Example-   guest_files_browse( path='\\vmname\\', show_deleted=True )
 
-                from_date           (str)   --  date to get the contents after
-                        format: dd/MM/YYYY
+                Refer Backupset.default_browse_options for all the supported options
 
-                        gets contents from 01/01/1970 if not specified
-                    default: None
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
 
-                to_date             (str)  --  date to get the contents before
-                        format: dd/MM/YYYY
-
-                        gets contents till current day if not specified
-                    default: None
-
-            Returns:
-                list - list of all folders or files with their full paths inside the input path
-
-                dict - path along with the details like name, file/folder, size, modification time
-
-            Raises:
-                SDKException:
-                    if from date value is incorrect
-
-                    if to date value is incorrect
-
-                    if to date is less than from date
-
-                    if failed to browse content
-
-                    if response is empty
-
-                    if response is not success
         """
-        browse_content = self.browse_in_time(
-            vm_path, show_deleted_files, restore_index, True, from_date, to_date
-        )
+
+        return self.browse(*args, **kwargs)
+
+    def vm_files_browse(self, *args, **kwargs):
+        """ Performs a browse operation on the subclient
+
+            Args:
+                Dictionary of browse options
+                    Example-  
+                        vm_files_browse({
+                            'path': '\\vmname\\',
+                            'show_deleted': True
+                        })
+
+                (or)
+
+                Keyword argument of browse options 
+                    Example-   vm_files_browse( path='\\vmname\\', show_deleted=True )
+
+                Refer Backupset.default_browse_options for all the supported options
+
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+
+        """
+
+        return self.browse(*args, **kwargs)
+
+    def disk_level_browse(self, *args, **kwargs):
+        """ Performs a browse operation on the subclient
+
+            Args:
+                Dictionary of browse options
+                    Example-  
+                        disk_level_browse({
+                            'path': '\\vmname\\',
+                            'show_deleted': True
+                        })
+
+                (or)
+
+                Keyword argument of browse options 
+                    Example-   disk_level_browse( path='\\vmname\\', show_deleted=True )
+
+                Refer Backupset.default_browse_options for all the supported options
+
+        Returns:
+            (list): List of only the file, folder paths from the browse response
+            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+
+        """
+
+        browse_content = self.browse(*args, **kwargs)
 
         paths_list = []
 
@@ -617,7 +367,10 @@ class VirtualServerSubclient(Subclient):
             destination_path,
             paths,
             overwrite=True,
-            restore_data_and_acl=True):
+            restore_data_and_acl=True,
+            copy_precedence=None,
+            from_time=None,
+            to_time=None):
         """Restores the VM Guest files/folders specified in the input paths list to the client,
             at the specified destionation location.
 

--- a/cvpysdk/subclients/vssubclient.py
+++ b/cvpysdk/subclients/vssubclient.py
@@ -244,13 +244,13 @@ class VirtualServerSubclient(Subclient):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   browse( path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00' )
+                    Example - browse( path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00' )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -284,15 +284,15 @@ class VirtualServerSubclient(Subclient):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   guest_files_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00'
+                    Example - guest_files_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00'
                     )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -314,15 +314,15 @@ class VirtualServerSubclient(Subclient):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   vm_files_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00'
+                    Example - vm_files_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00'
                     )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 
@@ -344,15 +344,15 @@ class VirtualServerSubclient(Subclient):
                 (or)
 
                 Keyword argument of browse options 
-                    Example-   disk_level_browse( 
-                        path='\\vmname\\', show_deleted=True, to_time = '2016-04-31 12:00:00 
+                    Example - disk_level_browse( 
+                        path='\\vmname\\', show_deleted=True, to_time='2016-04-31 12:00:00 
                     )
 
                 Refer Backupset.default_browse_options for all the supported options
 
         Returns:
-            (list): List of only the file, folder paths from the browse response
-            (dict): Dictionary of all the paths with additional metadata which are retrieved from browse
+            list - List of only the file, folder paths from the browse response
+            dict - Dictionary of all the paths with additional metadata which are retrieved from browse
 
         """
 


### PR DESCRIPTION
The browse function is now moved from subclient to backupset level.
It accepts dynamic arguments ( a dictionary of options or keyword arguments ). Default options for browse can be see in the backupset class init.

Redundant APIs like `browse_in_time` are removed as `browse` itself can be used.
With this change, browse now supports all the options which are supported in GUI including filters and can be easily extended for all requirements.

Return type of the browse function is unchanged.